### PR TITLE
Add playgame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rock-Paper-Scissors game
 
-
+This repository is focused in DDD and clean 
+architecture. The test are done with TDD methodology.
 
 ## How to run
 
@@ -11,3 +12,14 @@ This will run a docker container, receiving requests at `http://localhost:3000`.
 ## Run tests
 
 * `make test`
+
+## Endpoints
+
+- `POST` http://localhost:3000/api/play
+
+Body Format:
+```json
+{
+    "name": "Xabi",
+    "move": "rock"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "src/index.js" ,
   "license": "MIT",
   "scripts": {
-    "test": "npm run unit",
+    "test": "npm run unit && npm run acceptance",
+    "acceptance": "jest test/acceptance --coverage" ,
     "unit": "jest test/unit --coverage" ,
     "pretest": "npx eslint  --max-warnings 0"
   },
@@ -14,6 +15,7 @@
     "joi": "^17.5.0",
     "nodemon": "^2.0.15",
     "eslint": "^8.9.0",
-    "jest": "^27.5.1"
+    "jest": "^27.5.1",
+    "supertest": "^6.2.2"
   }
 }

--- a/src/game/infrastructure/createRequest.js
+++ b/src/game/infrastructure/createRequest.js
@@ -1,0 +1,35 @@
+module.exports = (controller, validate = null) => {
+    return (req, res) => {
+        const httpRequest = {
+            body: req.body,
+            query: req.query,
+            params: req.params,
+            ip: req.ip,
+            method: req.method,
+            path: req.path,
+            headers: {
+                "Content-Type": req.get("Content-Type"),
+                Referer: req.get("referer"),
+                "User-Agent": req.get("User-Agent")
+            }
+        };
+
+        if (validate) {
+            const validation = validate(httpRequest);
+            if (!validation.validates) {
+                return res.status(400).send({ error: validation.error });
+            }
+        }
+
+        controller(httpRequest)
+            .then(httpResponse => {
+                if (httpResponse.headers) {
+                    res.set(httpResponse.headers);
+                }
+                res.type("json");
+
+                res.status(httpResponse.statusCode).send(httpResponse.body);
+            })
+            .catch(() => res.status(500).send({ error: "An unkown error occurred." }));
+    };
+};

--- a/src/game/infrastructure/validation/createPlayGameValidation.js
+++ b/src/game/infrastructure/validation/createPlayGameValidation.js
@@ -1,0 +1,15 @@
+const Joi = require("joi");
+
+const schema = Joi.object({
+    name: Joi.string().alphanum().min(3).max(30).required(),
+    move: Joi.string().valid("rock", "paper", "scissors").required()
+});
+
+module.exports = () =>
+    ({ body }) => {
+        const validation = schema.validate(body);
+        if (validation.error) {
+            return { validates: false, error: validation.error.details[0].message };
+        }
+        return { validates: true };
+    };

--- a/src/game/infrastructure/validation/index.js
+++ b/src/game/infrastructure/validation/index.js
@@ -1,0 +1,5 @@
+const createPlayGameValidation = require("./createPlayGameValidation");
+
+const playGameValidation = createPlayGameValidation();
+
+module.exports = { playGameValidation };

--- a/src/game/interfaces/createPlayGame.js
+++ b/src/game/interfaces/createPlayGame.js
@@ -1,0 +1,26 @@
+const createUserPlaysGame = require("../../../src/game/application/createUserPlaysGame");
+const createBotMove = require("../../../src/game/application/createBotMove");
+const createCalculateResult = require("../../../src/game/application/createCalculateResult");
+
+module.exports = ({ getRandomInt }) => {
+    return async function (httpRequest) {
+        let body, statusCode;
+
+        const headers = { "Content-Type": "application/json" };
+
+        try {
+            const calculateResult = createCalculateResult();
+            const userPlaysGame = createUserPlaysGame({ createBotMove, calculateResult, getRandomInt });
+            body = userPlaysGame({
+                name: httpRequest.body.name,
+                move: httpRequest.body.move
+            });
+            statusCode = 200;
+        } catch (e) {
+            body = { error: e.message };
+            statusCode = 500;
+        }
+
+        return { headers, statusCode, body };
+    };
+};

--- a/src/game/interfaces/index.js
+++ b/src/game/interfaces/index.js
@@ -1,0 +1,6 @@
+const createPlayGame = require("./createPlayGame");
+const { getRandomInt } = require("../application");
+
+const playGame = createPlayGame({ getRandomInt });
+
+module.exports = { playGame };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,16 @@
 const express = require("express");
 const cors = require("cors");
 
+const { playGameValidation } = require("./game/infrastructure/validation");
+const { playGame } = require("./game/interfaces");
+const createRequest = require("./game/infrastructure/createRequest");
+
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+app.post("/api/play", createRequest(playGame, playGameValidation));
 
 module.exports = app.listen(3000, () => {
     console.log("Server started (http://localhost:3000/ externally) !");

--- a/test/acceptance/createRequest.test.js
+++ b/test/acceptance/createRequest.test.js
@@ -1,0 +1,44 @@
+const request = require("supertest");
+const app = require("../../src/index");
+
+describe("createRequest", function () {
+    describe("POST /api/play", function () {
+        describe("wrong parameters", function () {
+            it("should return a 400", function (done) {
+                const move = { name: "Xabi" };
+                request(app)
+                    .post("/api/play")
+                    .send(move)
+                    .expect("Content-Type", /json/)
+                    .expect(400)
+                    .end((err) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return done();
+                    });
+            });
+        });
+
+        describe("succesfull connection", function () {
+            it("should return a 200", function (done) {
+                const move = { name: "Xabi", move: "rock" };
+                request(app)
+                    .post("/api/play")
+                    .send(move)
+                    .expect("Content-Type", /json/)
+                    .expect(200)
+                    .end((err) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return done();
+                    });
+            });
+        });
+    });
+
+    afterAll( async () => {
+        app.close();
+    });
+});

--- a/test/unit/game/infrastructure/validation/createPlayGameValidation.test.js
+++ b/test/unit/game/infrastructure/validation/createPlayGameValidation.test.js
@@ -1,0 +1,62 @@
+const { playGameValidation } = require("../../../../../src/game/infrastructure/validation");
+
+describe("playGameValidation", function () {
+    describe("without data", function () {
+        let body;
+        beforeEach(function () {
+            body = {};
+        });
+        it("should not validate", function () {
+            const validation = playGameValidation({ body });
+            expect(validation.validates).toBe(false);
+        });
+    });
+
+    describe("with incorrect data", function () {
+        let body;
+        beforeEach(function () {
+            body = { name: 3, move: -2 };
+        });
+        it("should not validate", function () {
+            const validation = playGameValidation({ body });
+            expect(validation.validates).toBe(false);
+            expect(validation.error).toBe("\"name\" must be a string");
+        });
+    });
+
+    describe("with just name", function () {
+        let body;
+        beforeEach(function () {
+            body = { name: "Xabi" };
+        });
+        it("should not validate", function () {
+            const validation = playGameValidation({ body });
+            expect(validation.validates).toBe(false);
+            expect(validation.error).toBe("\"move\" is required");
+        });
+    });
+
+    describe("with just one parameter", function () {
+        let body;
+        beforeEach(function () {
+            body = { name: "Xabi" };
+        });
+        it("should not validate", function () {
+            const validation = playGameValidation({ body });
+            expect(validation.validates).toBe(false);
+            expect(validation.error).toBe("\"move\" is required");
+        });
+    });
+
+    describe("with correct parameter", function () {
+        let body;
+        beforeEach(function () {
+            body = { name: "Xabi", move: "rock" };
+        });
+        it("should validate", function () {
+            const validation = playGameValidation({ body });
+            expect(validation.validates).toBe(true);
+        });
+    });
+
+});

--- a/test/unit/game/interfaces/createPlayGame.test.js
+++ b/test/unit/game/interfaces/createPlayGame.test.js
@@ -1,0 +1,87 @@
+const createPlayGame = require("../../../../src/game/interfaces/createPlayGame");
+
+describe("playGame controller", function () {
+    let httpRequest, getRandomInt, playGame;
+    beforeEach(function () {
+        getRandomInt = () => 0;
+        playGame = createPlayGame({ getRandomInt });
+    });
+
+    describe("tie", function () {
+        beforeEach(function () {
+            httpRequest = {
+                body: {
+                    name: "Xabi",
+                    move: "rock"
+                }
+            };
+        });
+        it("should succesfully play a game", async function () {
+            const result = {
+                moves: [
+                    { name: "Xabi", move: "rock" },
+                    { name: "Bot", move: "rock" },
+                ],
+                result: {
+                    tie: true,
+                    winner: "none"
+                }
+            };
+
+            const game = await playGame(httpRequest);
+            expect(game.body).toEqual(result);
+        });
+    });
+
+    describe("player wins", function () {
+        beforeEach(function () {
+            httpRequest = {
+                body: {
+                    name: "Xabi",
+                    move: "paper"
+                }
+            };
+        });
+        it("should succesfully play a game", async function () {
+            const result = {
+                moves: [
+                    { name: "Xabi", move: "paper" },
+                    { name: "Bot", move: "rock" },
+                ],
+                result: {
+                    tie: false,
+                    winner: "Xabi"
+                }
+            };
+
+            const game = await playGame(httpRequest);
+            expect(game.body).toEqual(result);
+        });
+    });
+
+    describe("Bot wins", function () {
+        beforeEach(function () {
+            httpRequest = {
+                body: {
+                    name: "Xabi",
+                    move: "scissors"
+                }
+            };
+        });
+        it("should succesfully play a game", async function () {
+            const result = {
+                moves: [
+                    { name: "Xabi", move: "scissors" },
+                    { name: "Bot", move: "rock" },
+                ],
+                result: {
+                    tie: false,
+                    winner: "Bot"
+                }
+            };
+
+            const game = await playGame(httpRequest);
+            expect(game.body).toEqual(result);
+        });
+    });
+});


### PR DESCRIPTION
This adds createPlayGame to create the `playGame` controller for `/api/play` endpoint.

This also adds `createRequest` so we decouple request resolves from logic.